### PR TITLE
Fix typo in bibliography

### DIFF
--- a/poof.bib
+++ b/poof.bib
@@ -46,7 +46,7 @@
   year={1982}
 }
 
-@InProceedings{borning86,
+@InProceedings{Borning86,
   title={Classes Versus Prototypes in Object-Oriented Languages},
   author={A. H. Borning},
   booktitle={1986 Fall Joint Computer Conference},


### PR DESCRIPTION
Fix `make` failing due to typo.

```shell
> make
scribble --pdf poof.scrbl
bibtex: Unknown citation "Borning86"
```